### PR TITLE
Use a valid place holder network which is reserved for documentation

### DIFF
--- a/templates/ipwhitelist.php
+++ b/templates/ipwhitelist.php
@@ -44,7 +44,7 @@ style('bruteforcesettings', [
 
 	</table>
 
-	<input type="text" name="whitelist_ip" id="whitelist_ip" placeholder="1.2.3.4" style="width: 200px;" />/
-	<input type="number" id="whitelist_mask" name="whitelist_mask" placeholder="24" style="width: 50px;">
+	<input type="text" name="whitelist_ip" id="whitelist_ip" placeholder="2001:db8::" style="width: 200px;" />/
+	<input type="number" id="whitelist_mask" name="whitelist_mask" placeholder="64" style="width: 50px;">
 	<input type="button" id="whitelist_submit" value="<?php p($l->t('Add')); ?>">
 </form>


### PR DESCRIPTION
The IPv4 address 1.2.3.4 together with the 24 subnet mask are not a valid network because 1.2.3.4 is a host address with this mask.  On top of that 1.2.3.4 is not reserved for documentation.

This commit fixes both by using a valid IPv6 network reserved for documentation. I wanted to go with the legacy IPv4 equivalent of 203.0.113.0/24 at first with the argument that end users might be more familiar but then went with the SOTA IPv6 example to break the loop.

Follows: https://tools.ietf.org/html/rfc3849
Follows: https://tools.ietf.org/html/rfc5952