### PR TITLE
feat(settings): implement IDelegatedSettings for IP allowlist settings

### DIFF
--- a/lib/Settings/IPWhitelist.php
+++ b/lib/Settings/IPWhitelist.php
@@ -15,9 +15,9 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;
-use OCP\Settings\ISettings;
+use OCP\Settings\IDelegatedSettings;
 
-class IPWhitelist implements ISettings {
+class IPWhitelist implements IDelegatedSettings {
 	public function __construct(
 		protected IRequest $request,
 		protected IInitialState $initialState,
@@ -39,6 +39,16 @@ class IPWhitelist implements ISettings {
 	#[\Override]
 	public function getSection(): string {
 		return 'security';
+	}
+
+	#[\Override]
+	public function getName(): ?string {
+		return null;
+	}
+
+	#[\Override]
+	public function getAuthorizedAppConfig(): array {
+		return [];
 	}
 
 	#[\Override]


### PR DESCRIPTION
## Summary

Implements `IDelegatedSettings` for the IP allowlist settings page (`IPWhitelist`), instead of the plain `ISettings` interface. This allows a Nextcloud admin to delegate management of the brute-force IP allowlist to a non-admin user/group via the admin delegation feature, without granting full admin rights.

- `getName()` returns `null` (no distinct delegated-settings label beyond the section).
- `getAuthorizedAppConfig()` returns `[]` (no app config keys are exposed for direct delegated editing beyond the settings form itself).

## AI disclosure

This change was prepared with AI assistance (Claude Code), including the cherry-pick/rebase mechanics and this PR description draft. The underlying code change and sign-off are from a human contributor.

## Checklist

- [ ] DCO sign-off present on the commit
- [ ] Tests / lint pass